### PR TITLE
Fix typo: resettings -> resetting

### DIFF
--- a/src/Microsoft.VisualStudio.InteractiveWindow/InteractiveWindowResources.resx
+++ b/src/Microsoft.VisualStudio.InteractiveWindow/InteractiveWindowResources.resx
@@ -187,7 +187,7 @@
     <value>The interactive window has not yet been initialized.</value>
   </data>
   <data name="IsResettings" xml:space="preserve">
-    <value>The interactive window is resettings.</value>
+    <value>The interactive window is resetting.</value>
   </data>
   <data name="Parameters" xml:space="preserve">
     <value>Parameters:</value>


### PR DESCRIPTION
Loc folks were asking for clarification on this and bug to fix one character typo keeps getting punted. I'm going ahead and fixing the english string and will assign the clarification bug back to loc team to translate as though it had always been written correctly. I'm purposely not renaming the key so as not to reset the translation.

@ManishJayaswal