### PR TITLE
Avoid COM embedding

### DIFF
--- a/src/Microsoft.VisualStudio.VsInteractiveWindow/project.json
+++ b/src/Microsoft.VisualStudio.VsInteractiveWindow/project.json
@@ -10,7 +10,6 @@
     "Microsoft.VisualStudio.TextManager.Interop.10.0": "10.0.30319",
     "Microsoft.VisualStudio.TextManager.Interop.12.0": "12.0.30110",
     "Microsoft.VisualStudio.TextManager.Interop.12.1.DesignTime": "12.1.30328",
-    "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "14.1.2",
     "Microsoft.VisualStudio.ManagedInterfaces": "8.0.50727",
     "Microsoft.VisualStudio.WCFReference.Interop": "9.0.30729",
     "Microsoft.VisualStudio.Data.Core": "9.0.21022",


### PR DESCRIPTION
Avoid embedding VS COM interfaces to Microsoft.VisualStudio.VsInteractiveWindow.dll