### PR TITLE
Part of the fix for #37: Accessibility: Narrator issues

### DIFF
--- a/src/Microsoft.VisualStudio.VsInteractiveWindow/VsInteractiveWindow.cs
+++ b/src/Microsoft.VisualStudio.VsInteractiveWindow/VsInteractiveWindow.cs
@@ -4,8 +4,10 @@
 // #define DUMP_COMMANDS
 
 using System;
+using System.ComponentModel;
 using System.Runtime.InteropServices;
 using System.Windows;
+using System.Windows.Automation;
 using System.Windows.Input;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Editor;
@@ -112,6 +114,9 @@ namespace Microsoft.VisualStudio.InteractiveWindow.Shell
             _textViewHost = _window.GetTextViewHost();
             var textView = _textViewHost.TextView;
             textView.Options.SetOptionValue(EnableFindOptionName, true);
+            AutomationProperties.SetName(textView.VisualElement, Caption);
+            ((INotifyPropertyChanged)Frame).PropertyChanged += OnFramePropertyChanged;
+
             var viewAdapter = _editorAdapters.GetViewAdapter(textView);
             _findTarget = viewAdapter as IVsFindTarget;
             _commandTarget = viewAdapter as IOleCommandTarget;
@@ -120,6 +125,13 @@ namespace Microsoft.VisualStudio.InteractiveWindow.Shell
         private void SubmissionBufferAdded(object sender, SubmissionBufferAddedEventArgs e)
         {
             GetToolbarHost().ForceUpdateUI();
+        }
+
+        private void OnFramePropertyChanged(object sender, PropertyChangedEventArgs eventArgs)
+        {
+            if (eventArgs.PropertyName.Equals("Title", StringComparison.OrdinalIgnoreCase)) {
+                AutomationProperties.SetName(_textViewHost.TextView.VisualElement, Caption);
+            }
         }
 
         protected override void OnClose()


### PR DESCRIPTION
This is part of the fix for accessibility issue that changes "Text Editor" to the value from the `ToolWindowPane.Caption`, which represents one of the `WindowFrame` properties.

The issue with this fix though is that it heavily relies on the `Microsoft.VisualStudio.Platform.WindowManagement.WindowFrame` implementation, cause `Title` property isn't exposed through any of the public interfaces. 