### PR TITLE
Revert "Remove SwixBuild installation step"

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -15,6 +15,9 @@ steps:
     signType: real
     esrpSigning: true
 
+- task: ms-vseng.MicroBuildTasks.32f78468-e895-4f47-962c-58a699361df8.MicroBuildSwixPlugin@1
+  displayName: Install Swix Plugin
+
 - script: eng\common\CIBuild.cmd 
           -configuration $(BuildConfiguration)
           /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)


### PR DESCRIPTION
This reverts commit eabb101e2947f83797e45a4288b07f9a086a09e2.
The step sets some environment variables that are later used by VS insertion step.