### PR TITLE
Move off VS2017 queues

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,10 +52,10 @@ stages:
         pool:
           ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
             name: NetCorePublic-Pool
-            queue: BuildPool.Windows.10.Amd64.VS2017.Open
+            queue: BuildPool.Windows.10.Amd64.Open
           ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
             name: NetCoreInternal-Pool
-            queue: BuildPool.Windows.10.Amd64.VS2017
+            queue: BuildPool.Windows.10.Amd64.VS2019.Pre
         variables:
         # Only enable publishing in official builds
         - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:


### PR DESCRIPTION
Based on this comment - https://github.com/dotnet/interactive-window/pull/186#issuecomment-814510660

Moves to the queues that Roslyn CI uses.