### PR TITLE
Migrate richnav pipeline to 1ES hosted pools

### DIFF
--- a/azure-pipelines-richnav.yml
+++ b/azure-pipelines-richnav.yml
@@ -30,8 +30,8 @@ stages:
       jobs:
       - job: Windows
         pool:
-            name: NetCorePublic-Pool
-            queue: BuildPool.Windows.10.Amd64.Open
+            name: NetCore1ESPool-Public
+            demands: ImageOverride -equals Build.Windows.10.Amd64.Open
         variables:
           - name: _OfficialBuildArgs
             value: ''


### PR DESCRIPTION
Main `azure-pipelines.yml` has been already already migrated but we've missed the pool in `azure-pipelines-richnav.yml`. Tracking issue: https://github.com/dotnet/core-eng/issues/14276