### PR TITLE
Replace explicit richCodeNavigationEnvironment in azure-pipelines-richnav.yml

### DIFF
--- a/azure-pipelines-richnav.yml
+++ b/azure-pipelines-richnav.yml
@@ -17,7 +17,6 @@ stages:
   - template: /eng/common/templates/jobs/jobs.yml
     parameters:
       enableRichCodeNavigation: true
-      richCodeNavigationEnvironment: "production"
       richCodeNavigationLanguage: "csharp"
       enableMicrobuild: true
       enablePublishBuildArtifacts: true

--- a/azure-pipelines-richnav.yml
+++ b/azure-pipelines-richnav.yml
@@ -10,6 +10,9 @@ trigger:
     - README.md
     - docs/*
 
+variables:
+  - template: eng/common/templates/variables/pool-providers.yml
+
 stages:
 - stage: build
   displayName: Build
@@ -29,8 +32,8 @@ stages:
       jobs:
       - job: Windows
         pool:
-            name: NetCore-Public
-            demands: ImageOverride -equals windows.vs2019.amd64.open
+            name: $(DncEngPublicBuildPool)
+            demands: ImageOverride -equals windows.vs2022.amd64.open
         variables:
           - name: _OfficialBuildArgs
             value: ''

--- a/azure-pipelines-richnav.yml
+++ b/azure-pipelines-richnav.yml
@@ -29,7 +29,7 @@ stages:
       jobs:
       - job: Windows
         pool:
-            name: NetCore1ESPool-Public
+            name: NetCore-Public
             demands: ImageOverride -equals windows.vs2019.amd64.open
         variables:
           - name: _OfficialBuildArgs

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,6 +18,7 @@ schedules:
     - main
 
 variables:
+  - template: eng/common/templates/variables/pool-providers.yml
   - name: _TeamName
     value: Roslyn
   - name: _PublishUsingPipelines
@@ -51,10 +52,11 @@ stages:
       - job: Windows
         pool:
           ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-            vmImage: 'windows-latest'
+            name: $(DncEngPublicBuildPool)
+            demands: ImageOverride -equals windows.vs2022.amd64.open
           ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-            name: NetCore1ESPool-Internal
-            demands: ImageOverride -equals windows.vs2019.amd64
+            name: $(DncEngInternalBuildPool)
+            demands: ImageOverride -equals windows.vs2022.amd64
         variables:
         # Only enable publishing in official builds
         - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:


### PR DESCRIPTION
This is managed by the arcade defaults, we should be using the "internal" environment as requested by the RichNav team.

Also update to the correct AzDO pool name.