### PR TITLE
Create azure-pipelines-pr.yml

### DIFF
--- a/azure-pipelines-pr.yml
+++ b/azure-pipelines-pr.yml
@@ -1,0 +1,54 @@
+# Branches that trigger builds on PR
+pr:
+  branches:
+    include:
+    - main
+    - release/*
+  paths:
+    exclude:
+    - README.md
+    - docs/*
+
+variables:
+  - template: eng/common/templates/variables/pool-providers.yml
+  - name: _PublishUsingPipelines
+    value: true
+
+stages:
+- stage: build
+  displayName: Build
+  jobs:
+  - template: /eng/common/templates/jobs/jobs.yml
+    parameters:
+      enableMicrobuild: true
+      enablePublishBuildArtifacts: true
+      enablePublishTestResults: true
+      enablePublishBuildAssets: true
+      enablePublishUsingPipelines: $(_PublishUsingPipelines)
+      enableTelemetry: true
+      enableSourceBuild: false
+      helixRepo: dotnet/interactive-window
+      jobs:
+      - job: Windows
+        pool:
+          name: $(DncEngPublicBuildPool)
+          demands: ImageOverride -equals windows.vs2022.amd64.open
+        strategy:
+          matrix:
+            # PRs or external builds are not signed.
+            Debug:
+              _BuildConfig: Debug
+              _SignType: test
+              _DotNetPublishToBlobFeed: false
+              _BuildArgs: ''
+            Release:
+              _BuildConfig: Release
+              _SignType: test
+              _DotNetPublishToBlobFeed: false
+              _BuildArgs: ''
+        steps:
+        - checkout: self
+          clean: true
+
+        - script: eng\common\cibuild.cmd -configuration $(_BuildConfig) -prepareMachine $(_BuildArgs)
+          displayName: Build and Test


### PR DESCRIPTION
separating the PR build by creating azure-pipelines-pr as an effort to start off the 1ES migration effort