### PR TITLE
Migrate dn-bot-devdiv-drop-rw-code-rw PAT to WIF service connection

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -132,12 +132,22 @@ extends:
 
             # Publishes setup VSIXes to a drop.
             # Note: The insertion tool looks for the display name of this task in the logs.
+            - task: AzureCLI@2
+              displayName: Get DevDiv Drop Access Token
+              inputs:
+                azureSubscription: 'dnceng-devdiv-drop-rw-code-rw-wif'
+                scriptType: pscore
+                scriptLocation: inlineScript
+                inlineScript: |
+                  $token = az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv
+                  Write-Host "##vso[task.setvariable variable=DevDivDropAccessToken;issecret=true]$token"
+              condition: succeeded()
             - task: 1ES.MicroBuildVstsDrop@1
               displayName: Upload VSTS Drop
               inputs:
                 dropName: $(VisualStudioDropName)
                 dropFolder: 'artifacts\VSSetup\$(_BuildConfig)\Insertion'
-                accessToken: $(_DevDivDropAccessToken)
+                accessToken: $(DevDivDropAccessToken)
               condition: succeeded()
 
     - template: /eng/common/templates-official/post-build/post-build.yml@self
@@ -146,3 +156,4 @@ extends:
         # Symbol validation isn't being very reliable lately. This should be enabled back
         # once this issue is resolved: https://github.com/dotnet/arcade/issues/2871
         enableSymbolValidation: false
+


### PR DESCRIPTION
## Summary

Migrate the `dn-bot-devdiv-drop-rw-code-rw` PAT to Workload Identity Federation (WIF) for VSTS drop uploads.

## Changes

- Add `AzureCLI@2` step before `1ES.MicroBuildVstsDrop@1` to obtain a DevDiv-scoped access token via the `dnceng-devdiv-drop-rw-code-rw-wif` service connection
- Replace `accessToken: $(_DevDivDropAccessToken)` with the WIF-obtained `$(DevDivDropAccessToken)` variable

## Validation

- **Test build [2952263](https://dev.azure.com/dnceng/internal/_build/results?buildId=2952263)** — queued from `dev/mjanecke/wif-drop-token` branch on the AzDO mirror
  - ✅ `Get DevDiv Drop Access Token` (AzureCLI@2) — succeeded
  - ✅ `Upload VSTS Drop` (1ES.MicroBuildVstsDrop@1) — succeeded

## Context

Part of PAT-to-Entra migration tracked by [AB#10146](https://dev.azure.com/dnceng/internal/_workitems/edit/10146).
