### PR TITLE
Remove dead DotNet-VSTS-Infra-Access variable group reference

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -100,17 +100,13 @@ extends:
             variables:
             # Enable publishing in official builds
             # Publish-Build-Assets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT
-            # DotNet-VSTS-Infra-Access provides: dn-bot-devdiv-drop-rw-code-rw
             - group: Publish-Build-Assets
-            - group: DotNet-VSTS-Infra-Access
             - name: _OfficialBuildArgs
               value: /p:DotNetSignType=$(_SignType)
                     /p:TeamName=$(_TeamName)
                     /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
                     /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
                     /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
-            - name: _DevDivDropAccessToken
-              value: $(dn-bot-devdiv-drop-rw-code-rw)
             steps:
             - checkout: self
               clean: true


### PR DESCRIPTION
The \DotNet-VSTS-Infra-Access\ variable group (VG 4 in dnceng/internal) only contained the \dn-bot-devdiv-drop-r-code-r\ PAT which has been fully migrated to WIF:

- **WIF service connection**: \dnceng-devdiv-drop-rw-code-rw-wif\ (already in use by this pipeline's AzureCLI task)
- **PAT status**: Expired (May 31, 2026) and disabled in Key Vault
- **Secret manifest**: Removed from \.vault-config/product-builds-engkeyvault.yaml\

Changes:
1. Removed the \DotNet-VSTS-Infra-Access\ variable group reference (its only variable is stale)
2. Removed the unused \_DevDivDropAccessToken\ variable that referenced a non-existent VG variable (\dn-bot-devdiv-drop-rw-code-rw\). The actual drop token is acquired via the WIF \AzureCLI@2\ task which sets \DevDivDropAccessToken\ (the variable the drop task actually uses).

Related: https://dev.azure.com/dnceng/internal/_workitems/edit/10147