### PR TITLE
Remove unnecessary NuGetAuthenticate for public azure-public/vssdk feed

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -115,11 +115,6 @@ extends:
             - checkout: self
               clean: true
 
-            # Authenticate with service connections to be able to publish packages to external nuget feeds.
-            - task: NuGetAuthenticate@1
-              inputs:
-                nuGetServiceConnections: azure-public/vssdk
-
             - script: eng\common\cibuild.cmd -configuration $(_BuildConfig) -prepareMachine $(_OfficialBuildArgs)
               displayName: Build and Test
 


### PR DESCRIPTION
## Summary

Removes the \NuGetAuthenticate@1\ step that authenticates to the \zure-public/vssdk\ service connection. This feed is **publicly readable** and does not require authentication for NuGet restore operations.

## Verification

The feed responds with 200 (service index) without any auth headers:
- \https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json\

No push/publish operations target this feed from this repo (confirmed via org-wide code search).

## Context

Part of the dnceng PAT-to-Entra migration effort:
- [WI 10128](https://dnceng.visualstudio.com/internal/_workitems/edit/10128) — azure-public/vssdk

## Files Changed
- \zure-pipelines.yml\ — removed NuGetAuthenticate step for azure-public/vssdk