### PR TITLE
Revert "Remove unnecessary NuGetAuthenticate for public azure-public/vssdk feed"

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -115,6 +115,11 @@ extends:
             - checkout: self
               clean: true
 
+            # Authenticate with service connections to be able to publish packages to external nuget feeds.
+            - task: NuGetAuthenticate@1
+              inputs:
+                nuGetServiceConnections: azure-public/vssdk
+
             - script: eng\common\cibuild.cmd -configuration $(_BuildConfig) -prepareMachine $(_OfficialBuildArgs)
               displayName: Build and Test
 


### PR DESCRIPTION
Reverts dotnet/interactive-window#289.

**Reason:** The removed NuGetAuthenticate step was required for **package publishing**. The `eng/publish-assets.ps1` script pushes `Microsoft.VisualStudio.InteractiveWindow` and `Microsoft.VisualStudio.VsInteractiveWindow` packages to `azure-public/vside/_packaging/vssdk`, relying on the NuGet credential provider set up by NuGetAuthenticate.

**Impact:** Publish step will 401 once the earlier SBOM pipeline issues are resolved. Currently masked by unrelated failure.

**Root cause:** Same as dotnet/roslyn#84427 — code search missed the PowerShell-based publish path (`eng/publish-assets.ps1` → `dotnet nuget push`).