### PR TITLE
Migrate azure-public/vssdk feed auth from PAT to WIF service connection

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -111,10 +111,11 @@ extends:
             - checkout: self
               clean: true
 
-            # Authenticate with service connections to be able to publish packages to external nuget feeds.
+            # Authenticate to azure-public/vssdk feed via WIF service connection
             - task: NuGetAuthenticate@1
               inputs:
-                nuGetServiceConnections: azure-public/vssdk
+                azureDevOpsServiceConnection: dnceng-azure-public-vs-impl-push
+                feedUrl: https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json
 
             - script: eng\common\cibuild.cmd -configuration $(_BuildConfig) -prepareMachine $(_OfficialBuildArgs)
               displayName: Build and Test


### PR DESCRIPTION
Replace the PAT-backed `NuGetAuthenticate@1` (using `nuGetServiceConnections: azure-public/vssdk`) with WIF-based authentication using the `dnceng-azure-public-vs-impl-push` service connection.

This mirrors the same pattern used in the roslyn-official pipeline for the devdiv feeds.

## What changed
- Replaced `nuGetServiceConnections: azure-public/vssdk` with `azureDevOpsServiceConnection` + `feedUrl`
- Same SP has Contributor access on the vssdk feed in azure-public org
- No change to build logic — `publish-assets.ps1` continues to use the ambient NuGet credential provider

## Service Connection
- **Name:** `dnceng-azure-public-vs-impl-push`
- **ID:** 41dcefaa-632f-4c08-b8e5-af399561020b
- **Type:** workloadidentityuser → azure-public org

## Related
- AzDO WI 10128
- dotnet/roslyn#84457 (same migration for roslyn)